### PR TITLE
Download DB dump in chunks of 1MB

### DIFF
--- a/paragres/command.py
+++ b/paragres/command.py
@@ -118,7 +118,11 @@ class Command(object):
         try:
             db_file = urllib2.urlopen(url)
             with open(filename, 'wb') as output:
-                output.write(db_file.read())
+                while True:
+                    chunk = db_file.read(1024 * 1024)
+                    if chunk == '':
+                        break
+                    output.write(chunk)
             db_file.close()
         except Exception as e:
             self.error(str(e))

--- a/paragres/command.py
+++ b/paragres/command.py
@@ -120,7 +120,7 @@ class Command(object):
             with open(filename, 'wb') as output:
                 while True:
                     chunk = db_file.read(1024 * 1024)
-                    if chunk == '':
+                    if not chunk:
                         break
                     output.write(chunk)
             db_file.close()


### PR DESCRIPTION
If the DB dump is larger than available memory, it will fail with out-of-memory error. Downloading DB dump in 1mb chunks allows to avoid this issue.  